### PR TITLE
WIP: use conda-build-3.

### DIFF
--- a/check-glibc.sh
+++ b/check-glibc.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+if ! [ -d $1 ]; then
+    echo Folder $1 does not exist -- did you give a wrong destination or forget --single-version-externally-managed
+    exit 1
+fi
+
+fns=`find $1 -name '*.so'`
+for fn in $fns; do
+    echo "--- GLIBC symbols in $fn --"
+    objdump -T $fn | grep GLIBC | awk '
+        BEGIN { bad = 0 }
+        {print $0}
+        /GLIBC_2\.1[3-9]/ {
+            bad = 1
+        }
+        /GLIBC_2\.[2-9][0-9]/ {
+            bad = 1
+        }
+        END {
+            if (bad) print("Bad symbols detected");
+            exit bad;
+        }
+    '
+done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-if [ $(uname) == Darwin ]; then
-    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
-fi
-
-export LIBRARY_PATH="$PREFIX/lib"
-
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
             --enable-mpi-cxx \
             --enable-mpi-fortran
 
-make
+make -j$CPU_COUNT
 make install
+
+if [[ $OSTYPE != darwin* ]]; then
+    cp $RECIPE_DIR/../check-glibc.sh .
+    bash check-glibc.sh $PREFIX/lib/ || exit 1
+fi
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,16 +18,16 @@ build:
 
 requirements:
     build:
-        - toolchain
-        - gcc  # [not win]
+        - {{ compiler("c") }} # [not win]
+        - {{ compiler("cxx") }} # [not win]
+        - {{ compiler("fortran") }} # [not win]
         - perl
-    run:
-        - libgcc  # [linux]
-        - libgfortran  # [osx]
 
 test:
     requires:
-        - gcc  # [not win]
+        - {{ compiler("c") }} # [not win]
+        - {{ compiler("cxx") }} # [not win]
+        - {{ compiler("fortran") }} # [not win]
     files:
         - tests/helloworld.c
         - tests/helloworld.cxx


### PR DESCRIPTION
It is important to compile with conda-build-3 to ensure mpicc mpicxx mpifort to refer to the cross compilation toolchain, which allows building mpi based binary conda packages.